### PR TITLE
Match metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+test_notebook.py
+.vscode/.ropeproject/config.py
+.vscode/.ropeproject/objectdb
+HawkEyeScrapers/__pycache__/hawkeye_scraper_helpers.cpython-38.pyc

--- a/CricinfoScrapers/ball_by_ball_scraper.py
+++ b/CricinfoScrapers/ball_by_ball_scraper.py
@@ -11,15 +11,19 @@ import pandas as pd
 import numpy as np
 import re
 import json
-from helpers import get_soup_from_url
+import helpers
 
-def get_ball_by_ball_from_match_id(match_id, series_id='1', include_commentary=True):
-# Scrape ball by ball data from Cricinfo commentary for the match
-# Includes commentary text. This can be disabled to reduce data size
-# actual series_id is optional and "1" works as of 2019-06-02
+
+def get_ball_by_ball_from_match_id(match_id, include_commentary=True):
+    # Scrape ball by ball data from Cricinfo commentary for the match
+    # Includes commentary text. This can be disabled to reduce data size
+
+    series_id = helpers.get_series_id_from_match_page(
+        helpers.get_match_url_from_match_id(match_id))
 
     url_template = "http://site.web.api.espn.com/apis/site/v2/sports/cricket/{series_id}/playbyplay?event={match_id}&page={page_num}"
-    soup = get_soup_from_url(url_template.format(
+
+    soup = helpers.get_soup_from_url(url_template.format(
         series_id=str(series_id),
         match_id=str(match_id),
         page_num='1')
@@ -38,37 +42,40 @@ def get_ball_by_ball_from_match_id(match_id, series_id='1', include_commentary=T
                 )).text), strict=False)['commentary']['items']
             )
         except:
-            print('failed to get page{} of match{} of series{}'.format(str(i), str(match_id), str(series_id)))
+            print('failed to get page{} of match{} of series{}'.format(
+                str(i), str(match_id), str(series_id)))
     full_commentary = full_commentary_p1['items'] + [
         item for items in rest_of_full_commentary
         for item in items]
     if len(full_commentary) != total_count:
         print('total count does not match expected count')
-        
+
     # trim the unruly full_commentary bush and and flatten the dict to be converted into a df
-    
+
     trim_off_fields = ['clock',
-                         'id',
-                         'mediaId',
-                         'preText',
-                         'postText',
-                         'sequence',
-                         'shortText',
-                         'team',
-                         'athletesInvolved',
-                         'scoreValue',
-                         'homeScore',
-                         'awayScore',
-                         'media'
-                        ]
+                       'id',
+                       'mediaId',
+                       'preText',
+                       'postText',
+                       'sequence',
+                       'shortText',
+                       'team',
+                       'athletesInvolved',
+                       'scoreValue',
+                       'homeScore',
+                       'awayScore',
+                       'media'
+                       ]
     if not include_commentary:
         trim_off_fields = trim_off_fields + ['text']
-    sink_hole = [i.pop(k,None) for k in trim_off_fields for i in full_commentary]
-            
-    # remove playtype id = 0 
-    full_commentary = [i for i in full_commentary if i['playType']['id'] != '0']
+    sink_hole = [i.pop(k, None)
+                 for k in trim_off_fields for i in full_commentary]
 
-    for ix,item in enumerate(full_commentary):
+    # remove playtype id = 0
+    full_commentary = [
+        i for i in full_commentary if i['playType']['id'] != '0']
+
+    for ix, item in enumerate(full_commentary):
 
         full_commentary[ix]['playType'] = item['playType']['description']
 
@@ -96,7 +103,7 @@ def get_ball_by_ball_from_match_id(match_id, series_id='1', include_commentary=T
             full_commentary[ix]['other_batsman_balls_faced_cum'] = np.nan
             full_commentary[ix]['other_batsman_fours_cum'] = np.nan
             full_commentary[ix]['other_batsman_sixes_cum'] = np.nan
-        full_commentary[ix].pop('otherBatsman',None)
+        full_commentary[ix].pop('otherBatsman', None)
 
         full_commentary[ix]['bowler_id'] = item['bowler']['athlete']['id']
         full_commentary[ix]['bowler_name'] = item['bowler']['athlete']['displayName']
@@ -106,7 +113,7 @@ def get_ball_by_ball_from_match_id(match_id, series_id='1', include_commentary=T
         full_commentary[ix]['bowler_conceded_cum'] = item['bowler']['conceded']
         full_commentary[ix]['fielding_team_id'] = item['bowler']['team']['id']
         full_commentary[ix]['fielding_team_name'] = item['bowler']['team']['displayName']
-        full_commentary[ix].pop('bowler',None)
+        full_commentary[ix].pop('bowler', None)
 
         try:
             full_commentary[ix]['other_bowler_id'] = item['otherBowler']['athlete']['id']
@@ -124,7 +131,7 @@ def get_ball_by_ball_from_match_id(match_id, series_id='1', include_commentary=T
             full_commentary[ix]['other_bowler_wkts_cum'] = np.nan
             full_commentary[ix]['other_bowler_overs_cum'] = np.nan
             full_commentary[ix]['other_bowler_conceded_cum'] = np.nan
-        full_commentary[ix].pop('otherBowler',None)
+        full_commentary[ix].pop('otherBowler', None)
 
         full_commentary[ix]['dismissal_type'] = item['dismissal']['type']
         try:
@@ -133,9 +140,9 @@ def get_ball_by_ball_from_match_id(match_id, series_id='1', include_commentary=T
         except:
             full_commentary[ix]['dismissal_fielder_id'] = ''
             full_commentary[ix]['dismissal_fielder_name'] = ''
-        full_commentary[ix].pop('dismissal',None)
+        full_commentary[ix].pop('dismissal', None)
 
-        for k,v in item['innings'].items():
+        for k, v in item['innings'].items():
             if k == 'totalRuns':
                 full_commentary[ix]['score_for_play'] = v
             elif k == 'day':
@@ -144,36 +151,40 @@ def get_ball_by_ball_from_match_id(match_id, series_id='1', include_commentary=T
                 full_commentary[ix]['session'] = v
             elif k not in ['id', 'number', 'fallOfWickets', 'byes', 'noBalls', 'legByes', 'wides']:
                 full_commentary[ix][k] = v
-        full_commentary[ix].pop('innings',None)
+        full_commentary[ix].pop('innings', None)
 
-        for k,v in item['over'].items():
+        for k, v in item['over'].items():
             if k in ['noBall', 'wide', 'byes', 'legByes']:
                 full_commentary[ix][k] = v
             elif k == 'actual':
                 full_commentary[ix]['innings_ball'] = v
             elif k == 'unique':
                 full_commentary[ix]['innings_unique_ball'] = v
-        full_commentary[ix].pop('over',None)
+        full_commentary[ix].pop('over', None)
 
-        # using only date now 
-        # because I don't know what they are doing for timezone and 
+        # using only date now
+        # because I don't know what they are doing for timezone and
         # it doesn't look like they have actual time anyway
         full_commentary[ix]['date'] = item['date'][:-9]
         #full_commentary[ix]['date'] = pd.datetime.strptime(item['date'], '%Y-%m-%d')
-        
+
     # if kph or mph is not available, try to get it from commentary
     def look_for_speed_in_comment(txt, kph_or_mph):
-        if type(txt) != str: # found some NaNs show up when there is no commentary e.g. A to B, 1 wide,
+        if type(txt) != str:  # found some NaNs show up when there is no commentary e.g. A to B, 1 wide,
             return txt
         else:
             m = re.search('([0-9]+\.{{0,1}}[0-9]*)\s{{0,1}}{}m{{0,1}}ph'.format(kph_or_mph),
                           txt,
                           re.IGNORECASE)
             return float(m[1]) if m else np.nan
-    df =  pd.DataFrame.from_dict(full_commentary)
+    df = pd.DataFrame.from_dict(full_commentary)
     for unit in ['K', 'M']:
         col = 'speed{}PH'.format(unit)
         df[col] = df.apply(
-            lambda x: look_for_speed_in_comment(x['text'] if 'text' in x else '',unit), axis=1)
+            lambda x: look_for_speed_in_comment(x['text'] if 'text' in x else '', unit), axis=1)
     df['match_id'] = match_id
     return df
+
+
+match_id = 857713
+get_ball_by_ball_from_match_id(match_id)

--- a/CricinfoScrapers/ball_by_ball_scraper.py
+++ b/CricinfoScrapers/ball_by_ball_scraper.py
@@ -186,5 +186,9 @@ def get_ball_by_ball_from_match_id(match_id, include_commentary=True):
     return df
 
 
-match_id = 857713
-get_ball_by_ball_from_match_id(match_id)
+def umpires_from_match_id(match_id):
+    espn_soup = helpers.get_soup_from_url(
+        f"https://www.espncricinfo.com/matches/engine/match/{match_id}.html")
+    umpire_data = espn_soup.find(
+        "td", string=re.compile("Umpires")).nextSibling.find_all("h5")
+    return [i.text for i in umpire_data]

--- a/CricinfoScrapers/ball_by_ball_scraper.py
+++ b/CricinfoScrapers/ball_by_ball_scraper.py
@@ -35,7 +35,7 @@ def get_ball_by_ball_from_match_id(match_id, include_commentary=True):
     for i in range(2, page_count+1):
         try:
             rest_of_full_commentary.append(
-                json.loads(str(get_soup_from_url(url_template.format(
+                json.loads(str(helpers.get_soup_from_url(url_template.format(
                     series_id=str(series_id),
                     match_id=str(match_id),
                     page_num=str(i)

--- a/HawkEyeScrapers/hawkeye_scraper_helpers.py
+++ b/HawkEyeScrapers/hawkeye_scraper_helpers.py
@@ -48,7 +48,7 @@ def get_soup_from_url(url):
     # soup = BeautifulSoup(html,"lxml")
     soup = BeautifulSoup(html, "html.parser")
     # check if soup is empty
-    if not str(soup):
+    if str(soup):
         return str(soup)
     else:
         raise ValueError("url is empty")
@@ -147,3 +147,4 @@ def get_metadata_df_from_matchid(match_id):
 
 
 def try_for_hawkeye_data(match_id):
+    return 0

--- a/HawkEyeScrapers/hawkeye_scraper_helpers.py
+++ b/HawkEyeScrapers/hawkeye_scraper_helpers.py
@@ -51,7 +51,7 @@ def get_soup_from_url(url):
     if str(soup):
         return str(soup)
     else:
-        raise ValueError("url is empty")
+        raise ValueError("url is empty, no hawkeye data available")
 
 
 def get_tracking_df_from_matchid(match_id):

--- a/HawkEyeScrapers/hawkeye_scraper_helpers.py
+++ b/HawkEyeScrapers/hawkeye_scraper_helpers.py
@@ -47,7 +47,11 @@ def get_soup_from_url(url):
 
     # soup = BeautifulSoup(html,"lxml")
     soup = BeautifulSoup(html, "html.parser")
-    return str(soup)
+    # check if soup is empty
+    if not str(soup):
+        return str(soup)
+    else:
+        raise ValueError("url is empty")
 
 
 def get_tracking_df_from_matchid(match_id):
@@ -140,3 +144,6 @@ def get_metadata_df_from_matchid(match_id):
     return {'match_metadata': match_df,
             'player_metadata': player_df,
             'venue_metadata': venue_df}
+
+
+def try_for_hawkeye_data(match_id):

--- a/HawkEyeScrapers/hawkeye_scraper_helpers.py
+++ b/HawkEyeScrapers/hawkeye_scraper_helpers.py
@@ -15,6 +15,7 @@ import numpy as np
 import json
 import re
 
+
 def get_url_hawkeye(match_id):
     try:
         url = f'https://cricketapi-icc.pulselive.com//fixtures/{match_id}/uds/stats'
@@ -25,6 +26,7 @@ def get_url_hawkeye(match_id):
             url = f'https://cricketapi.platform.iplt20.com//fixtures/{match_id}/uds/stats'
     return url
 
+
 def get_url_metadata(match_id):
     try:
         url = f'https://cricketapi-icc.pulselive.com//fixtures/{match_id}/scoring'
@@ -32,8 +34,9 @@ def get_url_metadata(match_id):
         try:
             url = f'https://cricketapi.platform.bcci.tv//fixtures/{match_id}/scoring'
         except:
-			url = f'https://cricketapi.platform.iplt20.com//fixtures/{match_id}/scoring'			
+            url = f'https://cricketapi.platform.iplt20.com//fixtures/{match_id}/scoring'
     return url
+
 
 def get_soup_from_url(url):
     try:
@@ -41,89 +44,99 @@ def get_soup_from_url(url):
     except HTTPError:
         print("Link Cannot be Reached", url)
         return -1
-        
-    #soup = BeautifulSoup(html,"lxml")
-    soup = BeautifulSoup(html,"html.parser")
+
+    # soup = BeautifulSoup(html,"lxml")
+    soup = BeautifulSoup(html, "html.parser")
     return str(soup)
-  
+
+
 def get_tracking_df_from_matchid(match_id):
-  try:
-    df = pd.DataFrame(
-        [[k]+v.split(',') for i in json.loads(get_soup_from_url(get_url_hawkeye(match_id)))['data'] 
-         for k,v in i.items()],
-        columns = ['over','ball_num','batter','non-striker',
-                   'bowler','speed','catcher','dismissal_desc',
-                   'total_extras','runs','bowler_extras','extra_type',
-                  'otw','length','line','line_at_stumps',
-                  'height_at_stumps','shot_dist0','shot_dist1','blank2',
-                   'blank3','blank4']
-    )
-    df['match_id'] = str(match_id)
-    if ((df.shape[0] == 0) | 
-       ((df.speed.nunique() == 1) & 
-        (df.length.nunique() == 1) & 
-        (df.line.nunique() == 1) & 
-        (df.line_at_stumps.nunique() == 1) & 
-        (df.height_at_stumps.nunique() == 1))) :
+    try:
+        df = pd.DataFrame(
+            [[k]+v.split(',') for i in json.loads(get_soup_from_url(get_url_hawkeye(match_id)))['data']
+             for k, v in i.items()],
+            columns=['over', 'ball_num', 'batter', 'non-striker',
+                     'bowler', 'speed', 'catcher', 'dismissal_desc',
+                     'total_extras', 'runs', 'bowler_extras', 'extra_type',
+                     'otw', 'length', 'line', 'line_at_stumps',
+                     'height_at_stumps', 'shot_dist0', 'shot_dist1', 'blank2',
+                     'blank3', 'blank4']
+        )
+        df['match_id'] = str(match_id)
+        if ((df.shape[0] == 0) |
+           ((df.speed.nunique() == 1) &
+            (df.length.nunique() == 1) &
+            (df.line.nunique() == 1) &
+            (df.line_at_stumps.nunique() == 1) &
+                (df.height_at_stumps.nunique() == 1))):
+            return
+        else:
+            df['over'] = df.over.apply(lambda x: str(x).split('.'))
+            df['match_inn'] = df.over.apply(lambda x: x[0])
+            df['over_ball'] = pd.to_numeric(
+                df.over.apply(lambda x: x[2]), errors='coerce')
+            df['over_num'] = pd.to_numeric(
+                df.over.apply(lambda x: x[1]), errors='coerce')
+            df.drop('over', axis=1, inplace=True)
+
+            df['speed'] = pd.to_numeric(df['speed'], errors='coerce')*3.6
+            df.loc[df.speed < 0, 'speed'] = np.nan
+
+            df['length'] = pd.to_numeric(df['length'], errors='coerce')
+            df['line'] = pd.to_numeric(df['line'], errors='coerce')
+            df['line_at_stumps'] = pd.to_numeric(
+                df['line_at_stumps'], errors='coerce')
+            df['height_at_stumps'] = pd.to_numeric(
+                df['height_at_stumps'], errors='coerce')
+            df['deviation'] = df.line_at_stumps - df.line
+            return df
+    except:
+        print(
+            f"couldn't retrieve data for match {match_id}. Please check {get_url_hawkeye(match_id)} to debug")
         return
-    else:
-      df['over'] = df.over.apply(lambda x: str(x).split('.'))
-      df['match_inn'] = df.over.apply(lambda x: x[0])
-      df['over_ball'] = pd.to_numeric(df.over.apply(lambda x: x[2]), errors='coerce')
-      df['over_num'] = pd.to_numeric(df.over.apply(lambda x: x[1]), errors='coerce')
-      df.drop('over', axis=1, inplace=True)
 
-      df['speed'] = pd.to_numeric(df['speed'], errors='coerce')*3.6
-      df.loc[df.speed < 0, 'speed'] = np.nan
 
-      df['length'] = pd.to_numeric(df['length'], errors='coerce')
-      df['line'] = pd.to_numeric(df['line'], errors='coerce')
-      df['line_at_stumps'] = pd.to_numeric(df['line_at_stumps'], errors='coerce')
-      df['height_at_stumps'] = pd.to_numeric(df['height_at_stumps'], errors='coerce')
-      df['deviation'] = df.line_at_stumps - df.line
-      return df
-  except:
-    print(f"couldn't retrieve data for match {match_id}. Please check {get_url_hawkeye(match_id)} to debug")
-    return
-  
 def get_metadata_df_from_matchid(match_id):
-  m = json.loads(get_soup_from_url(get_url_metadata(match_id)))
-  this_match = pd.DataFrame([{k: v for k,v in m['matchInfo'].items() if k in [
-    'matchDate', 'matchEndDate','isLimitedOvers', 'description', 'matchType', 'tournamentLabel']}])
-  this_match['match_id'] = match_id
-  try:
-      this_match['toss_elected'] = m['matchInfo']['additionalInfo']['toss.elected']
-  except:
-      this_match['toss_elected'] = ''
-  this_match['venue_id'] = m['matchInfo']['venue']['id']
-  try:
-      this_match['team1_wk'] = m['matchInfo']['teams'][0]['wicketKeeper']['id']
-      this_match['team2_wk'] = m['matchInfo']['teams'][1]['wicketKeeper']['id']
-  except:
-      this_match['team1_wk'] = ''
-      this_match['team2_wk'] = ''
-  this_match['team1'] = m['matchInfo']['teams'][0]['team']['fullName']
-  this_match['team2'] = m['matchInfo']['teams'][1]['team']['fullName']
-  match_df = this_match
-  venue_df = pd.DataFrame([m['matchInfo']['venue']])])
-  player_df = pd.concat([pd.DataFrame(m['matchInfo']['teams'][0]['players']),
-                         pd.DataFrame(m['matchInfo']['teams'][1]['players'])
-                        ]).drop_duplicates()
-  
-  venue_df.drop('coordinates',axis=1, inplace=True)
-  player_df['batter_hand'] = player_df.rightHandedBat.apply(lambda x: 'R' if x else 'L')
-  player_df['bowler_hand'] = player_df.rightArmedBowl.apply(lambda x: 'R' if x else 'L')
-  match_df.matchType = match_df.apply(lambda x: 'W_' + x.matchType if 
-               re.search('women', x.tournamentLabel.lower()) else x.matchType,
-              axis=1)
-  match_df['toss_winner'] = match_df.toss_elected.apply(lambda x: str(x).strip().lower().split(',')[0])
-  match_df['toss_decision'] = match_df.toss_elected.apply(lambda x: str(x).lower().strip('.').split(' ')[-1])
-  match_df['toss_decision'] = match_df.toss_decision.apply(lambda x: 'field' if str(x)=='bowl' else str(x))
-  match_df['toss_decision'] = match_df.toss_decision.apply(lambda x: x if str(x) in ['field','bat'] else '')
-  match_df.drop('toss_elected', axis=1, inplace=True)
-  return {'match_metadata': match_df,
-          'player_metadata': player_df,
-          'venue_metadata': venue_df}
+    m = json.loads(get_soup_from_url(get_url_metadata(match_id)))
+    this_match = pd.DataFrame([{k: v for k, v in m['matchInfo'].items() if k in [
+        'matchDate', 'matchEndDate', 'isLimitedOvers', 'description', 'matchType', 'tournamentLabel']}])
+    this_match['match_id'] = match_id
+    try:
+        this_match['toss_elected'] = m['matchInfo']['additionalInfo']['toss.elected']
+    except:
+        this_match['toss_elected'] = ''
+    this_match['venue_id'] = m['matchInfo']['venue']['id']
+    try:
+        this_match['team1_wk'] = m['matchInfo']['teams'][0]['wicketKeeper']['id']
+        this_match['team2_wk'] = m['matchInfo']['teams'][1]['wicketKeeper']['id']
+    except:
+        this_match['team1_wk'] = ''
+        this_match['team2_wk'] = ''
+    this_match['team1'] = m['matchInfo']['teams'][0]['team']['fullName']
+    this_match['team2'] = m['matchInfo']['teams'][1]['team']['fullName']
+    match_df = this_match
+    venue_df = pd.DataFrame([m['matchInfo']['venue']])
+    player_df = pd.concat([pd.DataFrame(m['matchInfo']['teams'][0]['players']),
+                           pd.DataFrame(m['matchInfo']['teams'][1]['players'])
+                           ]).drop_duplicates()
 
-
-  
+    venue_df.drop('coordinates', axis=1, inplace=True, errors='ignore')
+    player_df['batter_hand'] = player_df.rightHandedBat.apply(
+        lambda x: 'R' if x else 'L')
+    player_df['bowler_hand'] = player_df.rightArmedBowl.apply(
+        lambda x: 'R' if x else 'L')
+    match_df.matchType = match_df.apply(lambda x: 'W_' + x.matchType if
+                                        re.search('women', x.tournamentLabel.lower()) else x.matchType,
+                                        axis=1)
+    match_df['toss_winner'] = match_df.toss_elected.apply(
+        lambda x: str(x).strip().lower().split(',')[0])
+    match_df['toss_decision'] = match_df.toss_elected.apply(
+        lambda x: str(x).lower().strip('.').split(' ')[-1])
+    match_df['toss_decision'] = match_df.toss_decision.apply(
+        lambda x: 'field' if str(x) == 'bowl' else str(x))
+    match_df['toss_decision'] = match_df.toss_decision.apply(
+        lambda x: x if str(x) in ['field', 'bat'] else '')
+    match_df.drop('toss_elected', axis=1, inplace=True)
+    return {'match_metadata': match_df,
+            'player_metadata': player_df,
+            'venue_metadata': venue_df}


### PR DESCRIPTION
Wrote a small function `umpires_from_match_id` that given a match id loads the Cricinfo HTML then finds the umpires. It appears that the Cricinfo JSON does not contain this info. I took inspiration from [python-espncricinfo](https://github.com/outside-edge/python-espncricinfo). It currently returns a list of strings containing the umpire's names.

I fixed a couple of bugs I found also whilst doing this.

1. `series_id=1` in `get_ball_by_ball_from_match_id` seems to no longer work. I amended the code to get the `series_id` given the `match_id`.
2. When looking for hawkeye data, if it is not available for the given `match_id`, `bs4` would return an empty string rather than `HTTPError`. I have added a check to account for this.

Other useful metadata should be easily extendable but I haven't had the time yet. Also, web scraping is a new use of python to me so my solution may be a bit clunky.